### PR TITLE
Chore/add TODO sections to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A base template for new dxw WordPress projects, including decision records.
 
 Click "Use this template" to start a new Github repo based on this template, or use `whippet generate app` to generate a repo locally.
 
-Follow the `TODO` instructions in this README to update it for your new repo, and then delete those instructions.
+Search for `TODO` in this README, and follow those instructions to update it for your new repo, and then delete those instructions.
 
 TODO: Remove the above sections from the README
 
@@ -53,3 +53,5 @@ script/setup
 Use [Whippet](https://github.com/dxw/whippet) to manage plugins or external themes.
 
 See the [theme README](wp-content/themes/theme/README.md) for more on how to develop the theme.
+
+TODO: Remove the `README.md` from `wp-content/themes/theme`, and rename `README.example.md` to `README.md`, updating it as needed.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,36 @@ A base template for new dxw WordPress projects, including decision records.
 
 Click "Use this template" to start a new Github repo based on this template, or use `whippet generate app` to generate a repo locally.
 
+Follow the `TODO` instructions in this README to update it for your new repo, and then delete those instructions.
+
+TODO: Remove the above sections from the README
+
+***
+
+# [Your Project Name]
+
+TODO: Replace the `[Your Project Name]` heading  above with the name of your project.
+
+Production: 
+Staging:
+
+TODO: Add the production & staging URLs to the above.
+
+Please use `main`/`develop` branches.
+
+## Project Management
+
+* Trello
+
+TODO: add the link to the Trello board
+
+## Ghost Inspector Tests
+
+* Production
+* Staging
+
+TODO: add the link to this site's Ghost Inspector tests
+
 ## Getting started
 
 Start the server:
@@ -14,7 +44,7 @@ Start the server:
 script/server
 ```
 
-Run the setup:
+Run the setup (first-time run only):
 
 ```
 script/setup
@@ -22,4 +52,4 @@ script/setup
 
 Use [Whippet](https://github.com/dxw/whippet) to manage plugins or external themes.
 
-See the [theme README](wp-content/themes/theme/README.md) for more on how to develop the custom theme included in this template.
+See the [theme README](wp-content/themes/theme/README.md) for more on how to develop the theme.

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,12 +1,9 @@
 # Whippet
 
-This site is built using Whippet, created by @thedxw. For more information, visit https://github.com/dxw/whippet.
+This site is built using Whippet and the WordPress Template, created and maintained by @dxw. For more information, visit https://github.com/dxw/whippet and https://github.com/dxw/wordpress-template/.
 
 You should replace this file with one that gives your team credit for the site you've built!
 
 (But if you'd like to keep this one too, that would be terribly nice.)
 
-## Whippet is maintained by...
-
-* Harry Metcalfe (@harrym)
-* Mallory Adams
+You can read more about dxw at https://dxw.com

--- a/wp-content/themes/theme/README.example.md
+++ b/wp-content/themes/theme/README.example.md
@@ -1,18 +1,4 @@
-# (Project title)
-
-* Production: https://
-* Staging: https://
-
-Please use `master/develop` branches
-
-## Project management
-
-* [Trello](...)
-
-## Ghost Inspector tests
-
-* [Production](...)
-* [Staging](...)
+# Theme
 
 ## Browser support
 
@@ -21,14 +7,21 @@ Please use `master/develop` branches
 
 ## Development
 
-[`wpc`](https://github.com/dxw/wpc)
+### Install the dependencies:
 
-## Set up checklist
+```
+composer install
+yarn install
+```
 
-- [ ] Activate at least the following plugins:
-  - (insert required plugins)
-- [ ] Activate theme
-- [ ] Create at least the following pages:
-  - (insert required pages)
-- [ ] Create at lest the following menu:
-  - (insert required menus)
+### Run the tests:
+
+```
+vendor/bin/kahlan spec
+```
+
+### Run the linter:
+
+```
+vendor/bin/php-cs-fixer fix
+```


### PR DESCRIPTION
This PR aims to make it clearer which part of the repo's docs need updating when you create a new project based on this repo, by adding `TODO` sections (similar to those in the [Rails template](https://github.com/dxw/rails-template)). This should help standardise our READMEs across projects. 

It also makes some minor updates to the docs to ensure they're up to date.