### PR TITLE
Fix/ignore risky files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,94 @@
+## IMPORTANT ##
+#
+# Usually a pattern here also belongs in your `.gitignore` file and vice versa.
+#
+# Note that Docker's ignore syntax is slightly different to Git's. The main
+# difference is that Git interprets patterns without a leading slash as applying
+# to any subdirectory, while Docker interprets them as relative to the project
+# root directory. To resolve that, a `.dockerignore` should prefix those
+# patterns with `**/`. This is also compatible with Git.
+#
+# This file is NOT a substitute for being intentional in copying directories to
+# a Docker image. Avoid use of `COPY . <destination>` in your `Dockerfile`s.
+#
+## How to use this file
+#
+# Add patterns to the section they apply to, sorted by:
+#
+#   1. absolute paths to or patterns for files (with a `/` prefix)
+#   2. absolute paths to or patterns for directories
+#   3. relative paths to or patterns for files (without a `/` prefix)
+#   4. relative paths to or patterns for directories
+#   5. pattern exceptions (sorted as above)
+#
+# Sort them alphanumerically within each section.
+#
+# If no section fits, create one. No path or pattern should exist without a
+# section or label.
+#
+
+## Sensitive files
+#
+# To override these ignored files on a case-by-case basis,
+# instead of adding a rule to this file, force add them:
+#
+# ```
+# git add path/to/file --force
+# ```
+#
+# This reduces the risk of accidentally committing files that happen to match
+# the ignore pattern exception, or a file being removed and readded
+# unintentionally in the future.
+#
+### Databases
+**/*.db*
+**/*.dump*
+**/*.sql*
+**/*.sqlite3*
+### Environment variables
+**/.env
+**/.env.*
+### Logs
+**/*.log*
+### Secrets and keys
+**/*.crt*
+**/*.key*
+**/*.pem*
+### Spreadsheet data
+**/*.bks*
+**/*.csv*
+**/*.dex*
+**/*.numbers*
+**/*.ods*
+**/*.ots*
+**/*.tsv*
+**/*.xlr*
+**/*.xls*
+### Terraform
+**/.terraformrc*
+**/terraform.rc*
+**/*.tfstate*
+**/*.tfvars*
+**/.terraform/
+### XML data
+**/*.xml*
+
+## Dependencies
+**/node_modules/
+/vendor/
+
+## Other node package managers
+**/package-lock.json
+
+## Temporary files
+**/tmp/
+
+## Build artifacts
+**/.php_cs.cache
+**/.sass-cache/
+**/*.bak*
+
+## Docker specific patterns ##
+#
+### Workflow configuration
+/.github/

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 ## Dependencies
+node_modules/
 vendor/
 
 ## WordPress media

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,30 @@
+## IMPORTANT ##
+#
+# Usually a pattern here also belongs in your `.dockerignore` file and vice
+# versa.
+#
+# Note that Docker's ignore syntax is slightly different to Git's. The main
+# difference is that Git interprets patterns without a leading slash as applying
+# to any subdirectory, while Docker interprets them as relative to the project
+# root directory. To resolve that, a `.dockerignore` should prefix those
+# patterns with `**/`. This is also compatible with Git.
+#
+## How to use this file
+#
+# Add patterns to the section they apply to, sorted by:
+#
+#   1. absolute paths to or patterns for files (with a `/` prefix)
+#   2. absolute paths to or patterns for directories
+#   3. relative paths to or patterns for files (without a `/` prefix)
+#   4. relative paths to or patterns for directories
+#   5. pattern exceptions (sorted as above)
+#
+# Sort them alphanumerically within each section.
+#
+# If no section fits, create one. No path or pattern should exist without a
+# section or label.
+#
+
 ## Sensitive files
 #
 # To override these ignored files on a case-by-case basis,

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 ## Dependencies
-/vendor/
+vendor/
 
 ## WordPress media
 /wp-content/uploads

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,18 @@
+## Dependencies
 /vendor/
+
+## WordPress media
 /wp-content/uploads
 
-# macOS
+## macOS
 .DS_Store
-# IDEs
+
+## IDEs
 .idea
-# Other node package managers
+
+## Other node package managers
 package-lock.json
+
+## Whippet dependencies
 /wp-content/plugins/akismet
 /wp-content/plugins/advanced-custom-fields-pro

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ vendor/
 ## Other node package managers
 package-lock.json
 
+## Temporary files
+tmp/
+
 ## Build artifacts
 .php_cs.cache
 .sass-cache/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ vendor/
 ## Other node package managers
 package-lock.json
 
+## Build artifacts
+.php_cs.cache
+.sass-cache/
+*.bak*
+
 ## Whippet dependencies
 /wp-content/plugins/akismet
 /wp-content/plugins/advanced-custom-fields-pro

--- a/.gitignore
+++ b/.gitignore
@@ -51,12 +51,6 @@ vendor/
 ## WordPress media
 /wp-content/uploads
 
-## macOS
-.DS_Store
-
-## IDEs
-.idea
-
 ## Other node package managers
 package-lock.json
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,49 @@
+## Sensitive files
+#
+# To override these ignored files on a case-by-case basis,
+# instead of adding a rule to this file, force add them:
+#
+# ```
+# git add path/to/file --force
+# ```
+#
+# This reduces the risk of accidentally committing files that happen to match
+# the ignore pattern exception, or a file being removed and readded
+# unintentionally in the future.
+#
+### Databases
+*.db*
+*.dump*
+*.sql*
+*.sqlite3*
+### Environment variables
+.env
+.env.*
+### Logs
+*.log*
+### Secrets and keys
+*.crt*
+*.key*
+*.pem*
+### Spreadsheet data
+*.bks*
+*.csv*
+*.dex*
+*.numbers*
+*.ods*
+*.ots*
+*.tsv*
+*.xlr*
+*.xls*
+### Terraform
+.terraformrc*
+terraform.rc*
+*.tfstate*
+*.tfvars*
+.terraform/
+### XML data
+*.xml*
+
 ## Dependencies
 node_modules/
 vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /vendor/
-/wp-content/whippet-wp-config.php
 /wp-content/uploads
 
 # macOS

--- a/wp-content/themes/theme/.gitignore
+++ b/wp-content/themes/theme/.gitignore
@@ -1,8 +1,0 @@
-/node_modules
-/.grunt
-/.npm-debug.log
-/vendor
-/.sass-cache
-/static/**/*.map
-/static/img/**/*.bak
-/.php_cs.cache


### PR DESCRIPTION
This PR:

* Implements a much more comprehensive `.gitignore`, that attempts to ensure we don't commit any sensitive data by accident. This is based largely on the [rails template equivalent](https://github.com/dxw/rails-template/pull/198/files), with some GovPress-specific tweaks
* Adds a corresponding `.dockerignore`, to help us avoid creating docker artefacts that contain sensitive data. Again, largely based on the [rails template equivalent](https://github.com/dxw/rails-template/pull/205), with some GovPress-specific tweaks
* Removes the theme-specific `.gitignore` that used to live in `wp-content/themes/theme/`, as the relevant rules this contained are now implemented in the root `.gitignore`
* Removes the empty `.gitignore` that lived in `wp-content/plugins/`.