### PR TITLE
Revert "Do not diff lock files"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-/composer.lock -diff
-/whippet.lock -diff

--- a/wp-content/themes/theme/.gitattributes
+++ b/wp-content/themes/theme/.gitattributes
@@ -1,2 +1,1 @@
 /static/** -diff
-/composer.lock -diff


### PR DESCRIPTION
This reverts commit 97785369843f5837a228b12ee430f09a601c2584.

We do want to be able to view the diff for composer.lock and
whippet.lock files, so we know exactly what plugins/dependencies have
updated, and to what new version.