### PR TITLE
Update whippet deps validate repo name

### DIFF
--- a/.github/workflows/whippet.yml
+++ b/.github/workflows/whippet.yml
@@ -5,4 +5,4 @@ on: [push, pull_request]
 jobs:
 
   whippet-deps-validate:
-    uses: dxw/govpress-workflows/.github/workflows/whippet-dependencies-validate.yml@v1
+    uses: dxw/govpress-workflow-whippet-validate/.github/workflows/whippet-dependencies-validate.yml@v1


### PR DESCRIPTION
We've renamed the repo that holds this reusable workflow to indicate it
just holds that single workflow (as, for versioning purposes, it makes
more sense for each reusable workflow to have its own repo).