### PR TITLE
Gitignore root composer.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,7 @@ package-lock.json
 tmp/
 
 ## Build artifacts
+/composer.lock
 .php_cs.cache
 .sass-cache/
 *.bak*


### PR DESCRIPTION
Because it would only contain Whippet as a dev dependency when generated, and we don't want
to accidentally commit it.