### PR TITLE
Revise dependabot rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,10 +20,16 @@ updates:
       - dependency-type: "production"
     schedule:
       interval: "daily"
+    # Prevent Dependabot opening PRs for non-security updates
+    # Our current build process would require manual intervention for these
+    open-pull-requests-limit: 0
 
   # Maintain theme dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/wp-content/themes/theme"
     schedule:
       interval: "daily"
+    # Prevent Dependabot opening PRs for non-security updates
+    # Our current build process would require manual intervention for these
+    open-pull-requests-limit: 0
   

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
   # Maintain root dependencies for Composer
   - package-ecosystem: "composer"
     directory: "/"
+    versioning-strategy: "increase"
     schedule:
       interval: "daily"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,24 @@
+---
 version: 2
 updates:
-
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-
-  # Maintain root dependencies for Composer
-  - package-ecosystem: "composer"
-    directory: "/"
-    versioning-strategy: "increase"
-    schedule:
-      interval: "daily"
-
-  # Maintain theme production dependencies for npm
-  - package-ecosystem: "npm"
-    directory: "/wp-content/themes/theme"
-    allow:
-      - dependency-type: "production"
-    schedule:
-      interval: "daily"
-    # Prevent Dependabot opening PRs for non-security updates
-    # Our current build process would require manual intervention for these
-    open-pull-requests-limit: 0
-
-  # Maintain theme dependencies for Composer
-  - package-ecosystem: "composer"
-    directory: "/wp-content/themes/theme"
-    schedule:
-      interval: "daily"
-    # Prevent Dependabot opening PRs for non-security updates
-    # Our current build process would require manual intervention for these
-    open-pull-requests-limit: 0
-  
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: composer
+  directory: "/wp-content/themes/theme"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 0
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 0
+- package-ecosystem: npm
+  directory: "/wp-content/themes/theme"
+  schedule:
+    interval: daily
+  allow:
+  - dependency-type: production
+  open-pull-requests-limit: 0


### PR DESCRIPTION
This PR:

* Disables non-security Dependabot updates for any dependencies aside from the root `composer.json` (which only contains Whippet). This is because our current build process would require manual intervention in order for these PRs to take effect when deployed, so it wouldn't be sustainable to manage automated PRs for non-security version bumps at the moment
* Sets the versioning-strategy for the root `composer.json` to "increase", to avoid the possibility of Dependabot specifying either of two (or more) major versions of Whippet. We'd want to know which major version we were running everywhere, so this will avoid that situation