### PR TITLE
Add dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,29 +1,24 @@
+---
 version: 2
 updates:
-
-  # Maintain dependencies for GitHub Actions
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-
-  # Maintain root dependencies for Composer
-  - package-ecosystem: "composer"
-    directory: "/"
-    schedule:
-      interval: "daily"
-
-  # Maintain theme production dependencies for npm
-  - package-ecosystem: "npm"
-    directory: "/wp-content/themes/theme"
-    allow:
-      - dependency-type: "production"
-    schedule:
-      interval: "daily"
-
-  # Maintain theme dependencies for Composer
-  - package-ecosystem: "composer"
-    directory: "/wp-content/themes/theme"
-    schedule:
-      interval: "daily"
-  
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+- package-ecosystem: composer
+  directory: "/wp-content/themes/theme"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 0
+- package-ecosystem: composer
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 0
+- package-ecosystem: npm
+  directory: "/wp-content/themes/theme"
+  schedule:
+    interval: daily
+  allow:
+  - dependency-type: production
+  open-pull-requests-limit: 0


### PR DESCRIPTION
This updates the existing `dependabot.yml` to fit with the auto-generated template rules (i.e. only security PRs should be opened).