### PR TITLE
Run dependabot.yml validation on push

### DIFF
--- a/.github/workflows/dependabot-validate.yml
+++ b/.github/workflows/dependabot-validate.yml
@@ -1,0 +1,17 @@
+name: Dependabot.yml validation
+
+on: [push]
+
+jobs:
+
+  dependabot-validate-composer:
+    uses: dxw/govpress-workflow-dependabot-validate/.github/workflows/dependabot-validate.yml@v1
+    with:
+      package-ecosystem: composer
+      package-filename: composer.json
+
+  dependabot-validate-npm:
+    uses: dxw/govpress-workflow-dependabot-validate/.github/workflows/dependabot-validate.yml@v1
+    with:
+      package-ecosystem: npm
+      package-filename: package.json


### PR DESCRIPTION
This PR adds a workflow that uses the new https://github.com/dxw/govpress-workflow-dependabot-validate workflow.

It searches the repo for any `composer.json` or `package.json` files, and then checks that they all have an entry in the repo's `dependabot.yml` file (i.e. they will be checked for security vulnerabilities). It doesn't check what ruleset has been been applied, just that an entry exists.