### PR TITLE
Add an editor config file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2
+
+[*.sh]
+indent_size = 2


### PR DESCRIPTION
Use an [.editorconfig](https://editorconfig.org/) file to automatically configure identation size, newline rules etc in supported text editors.

I've assumed 4 spaces for indenting everywhere but `*.sh` and `*.yml` which use 2 spaces, based on the existing files in this repo.