### PR TITLE
Add test runner script

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Once the server has started, the following containers will be running:
 
 For a /bin/sh console running on the WordPress container, run `script/console`
 For a MySQL console, run `bin/wp db cli`
+To run the php-cs-fixer linting and kahlan tests, run `script/test`
 
 ## Plugins & Themes
 

--- a/script/test
+++ b/script/test
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+exec docker-compose exec wordpress bash -c "cd ./wp-content/themes/\$(/usr/local/bin/wp theme list --status=active --field=name | cut -d\"/\" -f1) && vendor/bin/php-cs-fixer -v fix && vendor/bin/kahlan spec"


### PR DESCRIPTION
Allow the `php-cs-fixer` linting and `kahlan` tests within the themes directory to be run in development, without needing to first connect to the WordPress Docker container.

The script automatically detects the currently active theme, and runs the above within the theme's subdirectory.

