### PR TITLE
Starting development server pulls latest WordPress

### DIFF
--- a/script/server
+++ b/script/server
@@ -2,6 +2,8 @@
 set -e
 
 docker-compose down --remove-orphans
+docker-compose pull wordpress
+
 if test "$1" = "-d"; then
     docker-compose up -d
 else 


### PR DESCRIPTION
Amend the `script/server` command so that it pulls the latest WordPress
image from Docker before starting up. 

This ensures we're running the latest version of WordPress (according to the dxw Docker repo) and avoids a newer version being downloaded and installed every time the development server boots.