### PR TITLE
Feature/run ghostinspector tests on prod deploy pr

### DIFF
--- a/.github/workflows/ghost-inspector.yml
+++ b/.github/workflows/ghost-inspector.yml
@@ -1,0 +1,15 @@
+name: Run Ghost Inspector test suite
+
+on:
+  pull_request:
+    branches:
+      - 'main'
+
+jobs:
+
+  run-test-suite:
+    if:  startsWith(github.head_ref, 'develop')
+    uses: dxw/govpress-workflow-ghost-inspector/.github/workflows/ghost-inspector.yml@v1
+    secrets:
+      API_KEY: ${{ secrets.GHOST_INSPECTOR_API_KEY }}
+      SUITE_ID: ${{ secrets.GHOST_INSPECTOR_TEST_SUITE_ID_STAGING }}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,13 @@ TODO: add the link to the Trello board
 * Production
 * Staging
 
-TODO: add the link to this site's Ghost Inspector tests
+TODO: generate default Ghost Inspector test suites for staging p, using GovPress Tools:
+
+```bash
+govpress ghostinspector create-suite -s [dalmatian-service-name] -i [dalmatian-infrastructure name -e [dalmatian-environment]
+```
+
+Then add the link to this site's Ghost Inspector tests above
 
 ## Getting started
 


### PR DESCRIPTION
This PR:

- Adds a workflow to run staging GhostInspector tests when merging `develop` to `main`
- Update the README to include instructions on generating a default Ghost Inspector test suite using GovPress Tools