### PR TITLE
Fix/allow setup script to be run before server

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Then add the link to this site's Ghost Inspector tests above
 
 ## Getting started
 
+Run the setup (first-time run only):
+
+```
+script/setup
+```
+
 Start the server:
 
 ```
@@ -54,12 +60,6 @@ You can also run the server in detached mode (i.e. without any output to your co
 
 ```
 script/server -d
-```
-
-Run the setup (first-time run only):
-
-```
-script/setup
 ```
 
 Once the server has started, the following containers will be running:

--- a/script/setup
+++ b/script/setup
@@ -1,5 +1,19 @@
 #!/bin/sh
 set -e
 
+# Check if services running
+if ! docker compose ps | grep -q running; then
+  script/server -d
+fi
+
+# Wait for the MySQL container to be ready
+while ! docker-compose exec wordpress mysqladmin ping -hmysql -pfoobar --silent; do
+    echo "Waiting for MySQL instance to be ready..."
+    sleep 5
+done
+
+# Check for and install dependencies
 script/bootstrap
+
 docker-compose exec wordpress /usr/src/app/setup/internal.sh
+docker-compose down

--- a/script/setup
+++ b/script/setup
@@ -1,6 +1,9 @@
 #!/bin/sh
 set -e
 
+# Check for and install dependencies
+script/bootstrap
+
 # Check if services running
 if ! docker compose ps | grep -q running; then
   script/server -d
@@ -11,9 +14,6 @@ while ! docker-compose exec wordpress mysqladmin ping -hmysql -pfoobar --silent;
     echo "Waiting for MySQL instance to be ready..."
     sleep 5
 done
-
-# Check for and install dependencies
-script/bootstrap
 
 docker-compose exec wordpress /usr/src/app/setup/internal.sh
 docker-compose down

--- a/script/setup
+++ b/script/setup
@@ -5,8 +5,10 @@ set -e
 script/bootstrap
 
 # Check if services running
+already_running=1
 if ! docker compose ps | grep -q running; then
   script/server -d
+  already_running=0
 fi
 
 # Wait for the MySQL container to be ready
@@ -16,4 +18,7 @@ while ! docker-compose exec wordpress mysqladmin ping -hmysql -pfoobar --silent;
 done
 
 docker-compose exec wordpress /usr/src/app/setup/internal.sh
-docker-compose down
+
+if [ $already_running != 1 ]; then
+  docker-compose down
+fi


### PR DESCRIPTION
This PR updates the `script/setup` script so that it does not require `script/server` to be run first.

Instead, it now checks if the docker instances are already running, and if not, it starts them, runs the setup, then pull them down again. If they were already running, it runs the setup script, but does not pull the instances down at the end of the run.