### PR TITLE
Feature/offer backup before resetting site to known state

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -17,6 +17,35 @@ while ! docker-compose exec wordpress mysqladmin ping -hmysql -pfoobar --silent 
     sleep 5
 done
 
+# Check if the wordpress db already exists
+database_exists=0
+if bin/wp db tables --quiet >/dev/null; then
+  database_exists=1
+fi
+# If so, give the option to take a backup
+if [ $database_exists = 1 ]; then
+  echo "===> It looks like a database already exists for this site."
+  echo "===> Would you like to take a backup of the current db before it's overwritten? (y/n)"
+  read -r yn
+  case $yn in
+    [Yy]* ) 
+      mkdir -p setup/backups
+      timestamp=$(date "+%Y%m%d%H%M%S")
+      bin/wp db export "$timestamp".sql
+      docker compose cp wordpress:/var/www/html/"$timestamp".sql ./setup/backups/"$timestamp".sql
+      echo "===> Backup written to setup/backups/$timestamp.sql"
+      echo "===> You can restore the backup later with this command:" 
+      echo "bin/wp db import /usr/src/app/setup/backups/$timestamp.sql"
+      ;;
+    [Nn]* ) 
+      echo "===> Ok, proceeding without backup"
+      ;;
+    * ) 
+      echo "Please answer yes or no."
+      exit;;
+  esac
+fi
+
 docker-compose exec wordpress /usr/src/app/setup/internal.sh
 
 if [ $already_running != 1 ]; then

--- a/script/setup
+++ b/script/setup
@@ -12,8 +12,8 @@ if ! docker compose ps | grep -q running; then
 fi
 
 # Wait for the MySQL container to be ready
-while ! docker-compose exec wordpress mysqladmin ping -hmysql -pfoobar --silent; do
-    echo "Waiting for MySQL instance to be ready..."
+while ! docker-compose exec wordpress mysqladmin ping -hmysql -pfoobar --silent >/dev/null; do
+    echo "===> Waiting for MySQL instance to be ready..."
     sleep 5
 done
 

--- a/setup/internal.sh
+++ b/setup/internal.sh
@@ -15,6 +15,8 @@ theme=theme/templates
 plugins="advanced-custom-fields-pro"
 content=/usr/src/app/setup/content
 
+wp db reset --yes
+
 wp core install --skip-email --admin_user=admin --admin_password=admin --admin_email=admin@localhost.invalid --url=http://localhost --title="$title"
 # TODO: Uncomment for multisite
 #wp core multisite-install --skip-email --admin_user=admin --admin_password=admin --admin_email=admin@localhost.invalid --url=http://localhost --title="$title"


### PR DESCRIPTION
This PR revises the `script/setup` functionality, so it resets the database completely, and then runs setup steps on top of that reset db. This is in preparation for us writing setup scripts in PHP that will configure the site, add content etc., so we'll therefore want to be resetting the site to the same known state each time setup is run.

Before: when you ran the setup script, it wouldn't clear out the
database before running, it would just run the setup steps on top of
your existing database state. This was confusing, and not really what
the setup script is intended for (setting the site back to a known
state).

Now: when you run the setup script, the database will be reset, and the
setup steps run from a blank slate. In order to avoid this
unintentionally over-writing people's current database state, it checks
if a WordPress database currently exists, and if so prompts if you'd
like to take a backup. If you do, the script then provides you with the
command you'll need to run to restore that backup at a later date.