### PR TITLE
Feature/test script

### DIFF
--- a/.github/workflows/theme.yml
+++ b/.github/workflows/theme.yml
@@ -7,32 +7,7 @@ defaults:
     working-directory: wp-content/themes/theme
 
 jobs:
-  kahlan:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        php-versions: ['7.4']
-    steps:
-      - uses: actions/checkout@v2
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-versions }}
-      - name: Get Composer Cache Directory
-        id: composer-cache
-        run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
-      - uses: actions/cache@v2
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-      - name: Install dependencies
-        run: composer install --no-interaction
-      - name: Run Kahlan tests
-        run: vendor/bin/kahlan
-  php-cs-fixer:
+  lint_and_test:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -57,3 +32,5 @@ jobs:
         run: composer install --no-interaction
       - name: PHP CS fix
         run: vendor/bin/php-cs-fixer fix --dry-run -v --diff
+      - name: Run Kahlan tests
+        run: vendor/bin/kahlan

--- a/Brewfile
+++ b/Brewfile
@@ -1,0 +1,1 @@
+brew "shellcheck"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -17,11 +17,13 @@ if ! type "php" > /dev/null 2>&1; then
 fi
 
 if ! type "composer" > /dev/null 2>&1; then
-  echo "\033[96mWarning:\033[0m Please install Composer, https://getcomposer.org/download/"
+  echo "\033[96mWarning:\033[0m Please install Composer, 'brew install composer' or https://getcomposer.org/download/"
   exit 1
 fi
 
-composer install
+echo "===> Installing root Composer dependencies..."
+
+composer update
 
 if test -f whippet.json 2>&1; then
   if test -f whippet.lock 2>&1; then

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -25,6 +25,8 @@ echo "===> Installing root Composer dependencies..."
 
 composer update
 
+echo "===> Installing WordPress plugins..."
+
 if test -f whippet.json 2>&1; then
   if test -f whippet.lock 2>&1; then
     vendor/bin/whippet deps install
@@ -32,3 +34,11 @@ if test -f whippet.json 2>&1; then
     vendor/bin/whippet deps update
   fi
 fi
+
+echo "===> Installing theme Composer dependencies..."
+
+composer install -d ./wp-content/themes/theme
+
+echo "===> Installing theme Yarn dependencies..."
+
+yarn --cwd ./wp-content/themes/theme install

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+THEME_DIRECTORY="./wp-content/themes/theme"
+
 if ! type "docker" > /dev/null 2>&1; then
   echo "\033[96mWarning:\033[0m Please install Docker: https://docs.docker.com/docker-for-mac/install/"
   exit 1
@@ -44,8 +46,8 @@ fi
 
 echo "===> Installing theme Composer dependencies..."
 
-composer install -d ./wp-content/themes/theme
+composer install -d $THEME_DIRECTORY
 
 echo "===> Installing theme Yarn dependencies..."
 
-yarn --cwd ./wp-content/themes/theme install
+yarn --cwd $THEME_DIRECTORY install

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -21,6 +21,13 @@ if ! type "composer" > /dev/null 2>&1; then
   exit 1
 fi
 
+if [ -f Brewfile ] && [ "$(uname -s)" = "Darwin" ]; then
+  if ! brew bundle check >/dev/null 2>&1; then
+    echo "==> Installing Homebrew dependencies..."
+    brew bundle install --verbose --no-lock
+  fi
+fi
+
 echo "===> Installing root Composer dependencies..."
 
 composer update

--- a/script/test
+++ b/script/test
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+THEME_DIRECTORY="./wp-content/themes/theme"
+
+echo "===> Linting shell scripts..."
+
+./.shellcheck.sh
+
+echo "===> Linting theme files..."
+
+./wp-content/themes/theme/vendor/bin/php-cs-fixer fix --dry-run -v --diff  --config="$THEME_DIRECTORY/.php-cs-fixer.php"
+
+echo "===> Running theme unit tests..."
+./wp-content/themes/theme/vendor/bin/kahlan --spec="$THEME_DIRECTORY/spec"

--- a/script/test
+++ b/script/test
@@ -11,5 +11,8 @@ echo "===> Linting theme files..."
 
 ./wp-content/themes/theme/vendor/bin/php-cs-fixer fix --dry-run -v --diff  --config="$THEME_DIRECTORY/.php-cs-fixer.php"
 
+echo "===> Validating Whippet files..."
+vendor/bin/whippet deps validate
+
 echo "===> Running theme unit tests..."
 ./wp-content/themes/theme/vendor/bin/kahlan --spec="$THEME_DIRECTORY/spec"


### PR DESCRIPTION
This PR adds a new `script/test` script, that can be used to run all the tests associated with the template repo (and should then be edited to run all associated tests for any repos based on this template).

It also makes a couple of associated changes:

- `script/bootstrap` now installs theme dependencies (and shellcheck), as well as the root project dependencies, so that everything that's required to dev on the theme (and run the tests) is installed from a single script. Again, this should be modified on a per-project basis if required for projects that use this repo as a starting template
- in CI, the linter and unit tests are run as part of the same workflow job, rather than separate jobs. The setup required for both is identical, and is responsible for most of the time those workflows take to run. So consolidating them will speed up the CI pipeline, which in turn will save us GitHub action minutes.