### PR TITLE
Use tabs for whitespaces in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,12 +3,5 @@ root = true
 [*]
 end_of_line = lf
 insert_final_newline = true
-indent_style = space
-indent_size = 4
+indent_style = tab
 trim_trailing_whitespace = true
-
-[*.yml]
-indent_size = 2
-
-[*.sh]
-indent_size = 2


### PR DESCRIPTION
We've agreed this is more accessible and dev-friendly, and we'll also be updating our PHP linter config to reflect this.

When you're using tabs, there's no sense is specifying an indent size, as the developer will do that in their editor, so I've removed those.