### PR TITLE
Use `$THEME_DIRECTORY` variable consistently

### DIFF
--- a/script/test
+++ b/script/test
@@ -9,10 +9,10 @@ echo "===> Linting shell scripts..."
 
 echo "===> Linting theme files..."
 
-./wp-content/themes/theme/vendor/bin/php-cs-fixer fix --dry-run -v --diff  --config="$THEME_DIRECTORY/.php-cs-fixer.php"
+$THEME_DIRECTORY/vendor/bin/php-cs-fixer fix --dry-run -v --diff  --config="$THEME_DIRECTORY/.php-cs-fixer.php"
 
 echo "===> Validating Whippet files..."
 vendor/bin/whippet deps validate
 
 echo "===> Running theme unit tests..."
-./wp-content/themes/theme/vendor/bin/kahlan --spec="$THEME_DIRECTORY/spec"
+$THEME_DIRECTORY/vendor/bin/kahlan --spec="$THEME_DIRECTORY/spec"


### PR DESCRIPTION
Before: we were setting the `$THEME_DIRECTORY` variable at the start of the script, but then some of the theme directory paths were still hardcoded

Now: we use `$THEME_DIRECTORY` for all theme paths