### PR TITLE
Allow security PRs for prod and dev NPM dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,4 @@ updates:
   directory: "/wp-content/themes/theme"
   schedule:
     interval: daily
-  allow:
-    - dependency-type: production
   open-pull-requests-limit: 0


### PR DESCRIPTION
Before: Dependabot was configured to only open PRs for prod NPM dependencies. I think this was originally set up in the hope that it would prevent security alerts being opened for vulnerabilities in build dependencies. However, it doesn't prevent the alerts being raised, it just prevents Dependabot being able to automatically open PRs to fix them.

Now: we allow Dependabot to open PRs for both build and prod NPM dependencies. The open pull requests limit of 0 will still prevent Dependabot opening PRs for non-security updates (as that would result in an unmanageable number of PRs).