### PR TITLE
Chore/use updated whippet deps workflow

### DIFF
--- a/.github/workflows/whippet.yml
+++ b/.github/workflows/whippet.yml
@@ -5,4 +5,6 @@ on: [push, pull_request]
 jobs:
 
   whippet-deps-validate:
-    uses: dxw/govpress-workflow-whippet-validate/.github/workflows/whippet-dependencies-validate.yml@v1
+    uses: dxw/govpress-workflow-whippet-validate/.github/workflows/whippet-dependencies-validate.yml@v2
+    secrets:
+      GH_ACCOUNT_TOKEN: ${{ secrets.GOVPRESS_TOOLS_PLUGIN_READER_TOKEN }}

--- a/whippet.lock
+++ b/whippet.lock
@@ -4,7 +4,7 @@
         {
             "name": "akismet",
             "src": "git@github.com:dxw-wordpress-plugins/akismet",
-            "revision": "3c1bd3a1383b1fb0cb403967c48c6b946c84b847"
+            "revision": "8c7ad2b982bae5f878bf45d732961965aff5d008"
         },
         {
             "name": "advanced-custom-fields-pro",


### PR DESCRIPTION
This PR implements v2 of the `whippet-deps-validate` workflow, which will auto-comment on any PRs changing `whippet.lock` to show what the version changes will be.

I've run `whippet deps update` to illustrate what those comments look like.