### PR TITLE
Document the use of server-local.php for uncommitted config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ vendor/
 tmp/
 ## Build artifacts
 /composer.lock
+/config/server-local.php
 .php-cs-fixer.cache
 .sass-cache/
 *.bak*

--- a/config/server.php
+++ b/config/server.php
@@ -1,5 +1,10 @@
 <?php
 
+// Use this file for local server config we want to commit
+// e.g. defining constants we want all devs to have access to
+// Add a `server-local.php` file to this folder
+// For config you only want to use locally, without committing
+
 // TODO: uncomment for a multisite installation
 /*
 if(!defined('MULTISITE')) {


### PR DESCRIPTION
We use `config/server.php` for local dev config we want to commit for general use, and `config/server-local.php` for local dev config we don't want to commit (e.g. API keys).