### PR TITLE
Do not specify PHP version in root composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "config": {
         "platform": {
-            "php": "7.4.3"
+            "php": "8.2"
         }
     },
     "require-dev": {


### PR DESCRIPTION
The intention of the root composer file is just to ensure that Whippet is available for use in local development (or in automated workflows) without needing to be globally installed.

Any PHP version specified here neither indicates what PHP version the app is intended to run on (as none of the dependencies here are used in deployed code), nor should affect the output of any Whippet commands run.

So, for maximum compatibility as we're in the midst of the PHP7-to-8 switchover, let's not indicate a PHP version here at all.