### PR TITLE
Remove ::set-output

### DIFF
--- a/.github/workflows/theme.yml
+++ b/.github/workflows/theme.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(composer config cache-files-dir)"
+          echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
       - uses: actions/cache@v5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}


### PR DESCRIPTION
set-output is deprecated - using the suggested change from

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/