### PR TITLE
Add redis-cache plugin and sort plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ wp-content/php-error.php
 ## Whippet dependencies
 /wp-content/plugins/akismet
 /wp-content/plugins/advanced-custom-fields-pro
+/wp-content/plugins/redis-cache

--- a/whippet.json
+++ b/whippet.json
@@ -3,8 +3,8 @@
         "plugins": "git@github.com:dxw-wordpress-plugins/"
     },
     "plugins": [
-    	{"name": "akismet", "ref": "v5"},
     	{"name": "advanced-custom-fields-pro", "ref": "v6"},
+    	{"name": "akismet", "ref": "v5"},
     	{"name": "redis-cache", "ref": "v2"}
     ]
 }

--- a/whippet.json
+++ b/whippet.json
@@ -3,7 +3,8 @@
         "plugins": "git@github.com:dxw-wordpress-plugins/"
     },
     "plugins": [
-        {"name": "akismet", "ref": "v5"},
-        {"name": "advanced-custom-fields-pro", "ref": "v6"}
+    	{"name": "akismet", "ref": "v5"},
+    	{"name": "advanced-custom-fields-pro", "ref": "v6"},
+    	{"name": "redis-cache", "ref": "v2"}
     ]
 }

--- a/whippet.lock
+++ b/whippet.lock
@@ -1,5 +1,5 @@
 {
-    "hash": "64778640d5b58ae1c914a29e7a3cb8848f913027",
+    "hash": "2d84f7d25a48b3e60b2e59005cd6ef2341aa2a11",
     "plugins": [
         {
             "name": "akismet",
@@ -10,6 +10,11 @@
             "name": "advanced-custom-fields-pro",
             "src": "git@github.com:dxw-wordpress-plugins/advanced-custom-fields-pro",
             "revision": "ae897af1b3098a9caa139f75240b0ae266286d8e"
+        },
+        {
+            "name": "redis-cache",
+            "src": "git@github.com:dxw-wordpress-plugins/redis-cache",
+            "revision": "abdbcc1827df57d3a642e8ecce5379877f69bd45"
         }
     ]
 }

--- a/whippet.lock
+++ b/whippet.lock
@@ -1,15 +1,15 @@
 {
-    "hash": "2d84f7d25a48b3e60b2e59005cd6ef2341aa2a11",
+    "hash": "d3b0e69d479d842ac987338c073824dd032d4a31",
     "plugins": [
-        {
-            "name": "akismet",
-            "src": "git@github.com:dxw-wordpress-plugins/akismet",
-            "revision": "2322b839069dfe2726b3dc1566d540a3c6608eeb"
-        },
         {
             "name": "advanced-custom-fields-pro",
             "src": "git@github.com:dxw-wordpress-plugins/advanced-custom-fields-pro",
-            "revision": "ae897af1b3098a9caa139f75240b0ae266286d8e"
+            "revision": "547457df09e7d6a4cffea7f688eb847d572e7213"
+        },
+        {
+            "name": "akismet",
+            "src": "git@github.com:dxw-wordpress-plugins/akismet",
+            "revision": "f381147af2010e3e0d1011679dc59a2406333326"
         },
         {
             "name": "redis-cache",


### PR DESCRIPTION
This PR adds the redis-cache plugin to whippet.json and sorts the plugins array alphabetically.