### PR TITLE
docker-compose: By default bind only to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,12 @@ services:
   mailcatcher:
     image: schickling/mailcatcher
     ports:
-      - "1080:1080"
+      - "127.0.0.1:1080:1080"
 
   mysql:
     image: mariadb:10
     ports:
-      - "3306:3306"
+      - "127.0.0.1:3306:3306"
     volumes:
       - mysql_data:/var/lib/mysql
     environment:
@@ -20,7 +20,7 @@ services:
   wordpress:
     image: thedxw/wpc-wordpress:php8.2
     ports:
-      - "80:80"
+      - "127.0.0.1:80:80"
     links:
       - mysql
       - mailcatcher


### PR DESCRIPTION
To avoid allowing the services to run on all available networks by default bind the services to localhost.