### PR TITLE
docker-compose: By default bind only to localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,13 @@ services:
     image: schickling/mailcatcher
     ports:
       - "127.0.0.1:1080:1080"
+      - "[::1]:1080:1080"
 
   mysql:
     image: mariadb:10
     ports:
       - "127.0.0.1:3306:3306"
+      - "[::1]:3306:3306"
     volumes:
       - mysql_data:/var/lib/mysql
     environment:
@@ -21,6 +23,7 @@ services:
     image: thedxw/wpc-wordpress:php8.2
     ports:
       - "127.0.0.1:80:80"
+      - "[::1]:80:80"
     links:
       - mysql
       - mailcatcher


### PR DESCRIPTION
To avoid allowing the services to run on all available networks by default bind the services to localhost.