### PR TITLE
Use mariadb:12 image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - "[::1]:1080:1080"
 
   mysql:
-    image: mariadb:10
+    image: mariadb:12
     ports:
       - "127.0.0.1:3306:3306"
       - "[::1]:3306:3306"


### PR DESCRIPTION
The latest versions of mariadb-client used in our WordPress image require SSL by default. Mariadb 10 does not support this out of the box, causing our setup script to hang when it attempts to ping the sql container. Mariadb 12 supports SSL out of the box, resolving this issue.